### PR TITLE
Triton compatibility for Mesos

### DIFF
--- a/src/docker/docker.cpp
+++ b/src/docker/docker.cpp
@@ -381,6 +381,8 @@ Future<Nothing> Docker::run(
   argv.push_back("-e");
   argv.push_back("MESOS_SANDBOX=" + mappedDirectory);
 
+  /*
+
   foreach (const Volume& volume, containerInfo.volumes()) {
     string volumeConfig = volume.container_path();
     if (volume.has_host_path()) {
@@ -409,6 +411,8 @@ Future<Nothing> Docker::run(
   // Mapping sandbox directory into the container mapped directory.
   argv.push_back("-v");
   argv.push_back(sandboxDirectory + ":" + mappedDirectory);
+
+  */
 
   const string& image = dockerInfo.image();
 

--- a/src/master/master.cpp
+++ b/src/master/master.cpp
@@ -2816,7 +2816,13 @@ void Master::_accept(
 
           // Add task.
           if (pending) {
-            _offeredResources -= addTask(task_, framework, slave);
+            Resources taskResources; Resources ports;
+            taskResources = addTask(task_, framework, slave);
+            ports = taskResources.get("ports");
+            taskResources -= ports;
+
+	    _offeredResources -= taskResources;
+
 
             // TODO(bmahler): Consider updating this log message to
             // indicate when the executor is also being launched.

--- a/src/slave/containerizer/docker.cpp
+++ b/src/slave/containerizer/docker.cpp
@@ -1303,10 +1303,13 @@ void DockerContainerizerProcess::destroy(
     container->termination.set(termination);
 
     containers_.erase(containerId);
+
+    remove(container->name(), None());
     delete container;
 
     return;
   }
+
 
   if (container->state == Container::DESTROYING) {
     // Destroy has already been initiated.
@@ -1348,6 +1351,8 @@ void DockerContainerizerProcess::destroy(
     // removing the container here means that we won't proceed with
     // the Docker::run.
     containers_.erase(containerId);
+
+    remove(container->name(), None());
     delete container;
 
     return;
@@ -1365,6 +1370,8 @@ void DockerContainerizerProcess::destroy(
     container->termination.set(termination);
 
     containers_.erase(containerId);
+
+    remove(container->name(), None());
     delete container;
 
     return;
@@ -1456,6 +1463,7 @@ void DockerContainerizerProcess::__destroy(
       container->name(),
       container->executorName());
 
+    remove(container->name(), None());
     delete container;
 
     return;
@@ -1499,6 +1507,8 @@ void DockerContainerizerProcess::___destroy(
     container->name(),
     container->executorName());
 
+
+  remove(container->name(), None());
   delete container;
 }
 

--- a/src/slave/containerizer/docker.hpp
+++ b/src/slave/containerizer/docker.hpp
@@ -257,8 +257,12 @@ private:
 
     static std::string name(const SlaveID& slaveId, const std::string& id)
     {
-      return DOCKER_NAME_PREFIX + slaveId.value() + DOCKER_NAME_SEPERATOR +
-        stringify(id);
+      std::string slaveIdstring = slaveId.value();
+      std::transform(slaveIdstring.begin(), slaveIdstring.end(),
+		     slaveIdstring.begin(), ::tolower);
+
+      return DOCKER_NAME_PREFIX + slaveIdstring + DOCKER_NAME_SEPERATOR +
+             stringify(id);
     }
 
     Container(const ContainerID& id)


### PR DESCRIPTION
To make Mesos compatible with Triton a couple of changes are required. Triton is a Docker deployment service which will deploy containers across an entire data center. The Triton implementation of Docker increases the scalability, security and reliability of docker while maintaining bare metal performance. Mesos can offer further elasticity to Triton when it comes to deployment of containers across data centers, as well as provide a variety of frameworks that can take advantage of Triton as a service. 

I used the following slide deck to outline discussion of the opportunity, my solution so far, and outstanding questions we should consider in doing this:

https://docs.google.com/presentation/d/1o6EfTteCDqKwneVRS7tDnvbVmoatvyX6pQQ_kWGQO9I/edit?usp=sharing
### Architecture

In traditional Mesos deployments, a Mesos slave runs on each physical host, but Triton's approach to containers eliminates the notion of a host and treats the entire data center as a single host. In Triton, a Mesos Slave is used to represent an entire data center, rather than a single host. Multiple data centers can be addressed via multiple slaves to support multi-region deployments.

Each slave represents an entire data center, instead of a single physical host, but the relationship between the slave(s) and the master and schedulers or other Mesos components is unchanged. This has been tested with Marathon, which runs unchanged. We expect that other frameworks on top of Mesos will work unchanged as well.
### Necessary alterations
##### Mesos sandbox and Docker volumes

Triton for a variety of reasons has its host volumes as read only and thus, the `-v` flag linking host volumes has been disabled. In turn we must disable the Mesos-Docker Executor from attempting to add the volume link between the established `MESOS_SANDBOX` and the docker volumes. We do not however interfere with Mesos establishing a location for the stderr and stdout files (`MESOS_SANDBOX`) as it is foreseeable that we find a roundabout way of migrating these files into the `MESOS_SANDBOX`.
##### Port mapping

Mesos views ports as a consumable resource, however in Triton, where each container gets a unique NIC and IP address, port collisions are impossible and this functionality is no longer warranted. As a result we still track the ports as a resource however whenever a container is created we will not “consume” (remove) the used port from the slaves resources. 
##### Container naming

A minor inconsistency between the Mesos executor and Docker is that the Mesos executor constructs container names by piecing together the executor name with other elements. Unfortunately, the Mesos executor can include capital letters which are not allowed in the names of Docker containers. As a result, illegal names are causing Docker name failures for some requests. The changeset modifies the behavior to coerce container names to fit Docker convention in the executor.
##### Docker container removal upon destruction

When destroying a Docker container, Mesos would send a `docker kill` but leave the stopped container in place. Garbage collection issues arose as a result, so we addressed that by removing the container with a `docker rm` after killing it.
### Next steps
1. Dockerize this. It's tested now with all the pieces manually installed and running in an infrastructure container. That probably includes creating a custom Dockerfile for the slave.
2. Identify which of these changes should be treated as bugs in upstream code. Container naming is a significant issue.
3. Try to genericize the changes, possibly turn some of them into switches that can be triggered at runtime, so that we can upstream them.
