### PR TITLE
Triton compatibility for Mesos 0.23.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,3 +39,5 @@ WORKDIR /opt/build
 
 # build and cleanup in a single layer
 RUN make -j4 install && cd / && rm -rf /opt
+
+WORKDIR /

--- a/src/docker/docker.cpp
+++ b/src/docker/docker.cpp
@@ -127,6 +127,7 @@ Try<Docker*> Docker::create(const string& path, bool validate)
     return docker;
   }
 
+/*
 #ifdef __linux__
   // Make sure that cgroups are mounted, and at least the 'cpu'
   // subsystem is attached.
@@ -139,6 +140,7 @@ Try<Docker*> Docker::create(const string& path, bool validate)
                  "to mount cgroups manually");
   }
 #endif // __linux__
+*/
 
   Try<Nothing> validateVersion = docker->validateVersion(Version(1, 0, 0));
   if (validateVersion.isError()) {

--- a/src/docker/docker.cpp
+++ b/src/docker/docker.cpp
@@ -399,6 +399,8 @@ Future<Nothing> Docker::run(
   argv.push_back("-e");
   argv.push_back("MESOS_SANDBOX=" + mappedDirectory);
 
+  /*
+
   foreach (const Volume& volume, containerInfo.volumes()) {
     string volumeConfig = volume.container_path();
     if (volume.has_host_path()) {
@@ -427,6 +429,8 @@ Future<Nothing> Docker::run(
   // Mapping sandbox directory into the container mapped directory.
   argv.push_back("-v");
   argv.push_back(sandboxDirectory + ":" + mappedDirectory);
+
+  */
 
   const string& image = dockerInfo.image();
 

--- a/src/master/master.cpp
+++ b/src/master/master.cpp
@@ -2828,7 +2828,13 @@ void Master::_accept(
 
           // Add task.
           if (pending) {
-            _offeredResources -= addTask(task_, framework, slave);
+            Resources taskResources; Resources ports;
+            taskResources = addTask(task_, framework, slave);
+            ports = taskResources.get("ports");
+            taskResources -= ports;
+
+	    _offeredResources -= taskResources;
+
 
             // TODO(bmahler): Consider updating this log message to
             // indicate when the executor is also being launched.

--- a/src/slave/containerizer/docker.cpp
+++ b/src/slave/containerizer/docker.cpp
@@ -1297,10 +1297,13 @@ void DockerContainerizerProcess::destroy(
     container->termination.set(termination);
 
     containers_.erase(containerId);
+
+    remove(container->name(), None());
     delete container;
 
     return;
   }
+
 
   if (container->state == Container::DESTROYING) {
     // Destroy has already been initiated.
@@ -1342,6 +1345,8 @@ void DockerContainerizerProcess::destroy(
     // removing the container here means that we won't proceed with
     // the Docker::run.
     containers_.erase(containerId);
+
+    remove(container->name(), None());
     delete container;
 
     return;
@@ -1359,6 +1364,8 @@ void DockerContainerizerProcess::destroy(
     container->termination.set(termination);
 
     containers_.erase(containerId);
+
+    remove(container->name(), None());
     delete container;
 
     return;
@@ -1450,6 +1457,7 @@ void DockerContainerizerProcess::__destroy(
       container->name(),
       container->executorName());
 
+    remove(container->name(), None());
     delete container;
 
     return;
@@ -1493,6 +1501,8 @@ void DockerContainerizerProcess::___destroy(
     container->name(),
     container->executorName());
 
+
+  remove(container->name(), None());
   delete container;
 }
 

--- a/src/slave/containerizer/docker.hpp
+++ b/src/slave/containerizer/docker.hpp
@@ -257,8 +257,12 @@ private:
 
     static std::string name(const SlaveID& slaveId, const std::string& id)
     {
-      return DOCKER_NAME_PREFIX + slaveId.value() + DOCKER_NAME_SEPERATOR +
-        stringify(id);
+      std::string slaveIdstring = slaveId.value();
+      std::transform(slaveIdstring.begin(), slaveIdstring.end(),
+		     slaveIdstring.begin(), ::tolower);
+
+      return DOCKER_NAME_PREFIX + slaveIdstring + DOCKER_NAME_SEPERATOR +
+             stringify(id);
     }
 
     Container(const ContainerID& id)


### PR DESCRIPTION
Updated Triton compatibility, now for the [0.23.1 release](https://github.com/apache/mesos/releases/tag/0.23.1).

Includes patches originally applied to https://github.com/joyent/mesos/tree/triton in https://github.com/joyent/mesos/pull/1 and other commits (which was applied to a fork of https://github.com/apache/mesos/commit/e9eb5bb4f86bb64d0bddf32e400be977841b3f67). 

For my own memory, here's the transcript of work I did to fork the release tag and re-apply the Triton-specific changes:

``` bash
git checkout -b 0.23.1-triton 0.23.1 # to make a new branch based on the release tag
git push joyent 0.23.1-triton # to push a clean branch to the Joyent fork

# then cherry pick the commits
git cherry-pick 53c200093bf8b70af8ce69dcb19a47eaaaf7c7fd
git cherry-pick 07c58308a8ee8f816e5c318fe8d8dce2bef9dd3f
git cherry-pick ff2c56508695f6859704d10bff7dc91a51ea167f

git push misterbisson HEAD # to push the above changes to my fork, then I can PR them back to Joyent's
```

The above changes all merged without conflicts, and no additional changes were made for compatibility. The heavy lifting here was done by @blakeolsen. The following comes from [his big PR](https://github.com/joyent/mesos/pull/1)...

---

To make Mesos compatible with Triton a couple of changes are required. Triton is a Docker deployment service which will deploy containers across an entire data center. The Triton implementation of Docker increases the scalability, security and reliability of docker while maintaining bare metal performance. Mesos can offer further elasticity to Triton when it comes to deployment of containers across data centers, as well as provide a variety of frameworks that can take advantage of Triton as a service. 

I used the following slide deck to outline discussion of the opportunity, my solution so far, and outstanding questions we should consider in doing this:

https://docs.google.com/presentation/d/1o6EfTteCDqKwneVRS7tDnvbVmoatvyX6pQQ_kWGQO9I/edit?usp=sharing
### Architecture

In traditional Mesos deployments, a Mesos slave runs on each physical host, but Triton's approach to containers eliminates the notion of a host and treats the entire data center as a single host. In Triton, a Mesos Slave is used to represent an entire data center, rather than a single host. Multiple data centers can be addressed via multiple slaves to support multi-region deployments.

Each slave represents an entire data center, instead of a single physical host, but the relationship between the slave(s) and the master and schedulers or other Mesos components is unchanged. This has been tested with Marathon, which runs unchanged. We expect that other frameworks on top of Mesos will work unchanged as well.
### Necessary alterations
##### Mesos sandbox and Docker volumes

Triton for a variety of reasons has its host volumes as read only and thus, the `-v` flag linking host volumes has been disabled. In turn we must disable the Mesos-Docker Executor from attempting to add the volume link between the established `MESOS_SANDBOX` and the docker volumes. We do not however interfere with Mesos establishing a location for the stderr and stdout files (`MESOS_SANDBOX`) as it is foreseeable that we find a roundabout way of migrating these files into the `MESOS_SANDBOX`.
##### Port mapping

Mesos views ports as a consumable resource, however in Triton, where each container gets a unique NIC and IP address, port collisions are impossible and this functionality is no longer warranted. As a result we still track the ports as a resource however whenever a container is created we will not “consume” (remove) the used port from the slaves resources. 
##### Container naming

A minor inconsistency between the Mesos executor and Docker is that the Mesos executor constructs container names by piecing together the executor name with other elements. Unfortunately, the Mesos executor can include capital letters which are not allowed in the names of Docker containers. As a result, illegal names are causing Docker name failures for some requests. The changeset modifies the behavior to coerce container names to fit Docker convention in the executor.
##### Docker container removal upon destruction

When destroying a Docker container, Mesos would send a `docker kill` but leave the stopped container in place. Garbage collection issues arose as a result, so we addressed that by removing the container with a `docker rm` after killing it.
### Next steps
1. Dockerize this. It's tested now with all the pieces manually installed and running in an infrastructure container. That probably includes creating a custom Dockerfile for the slave.
2. Identify which of these changes should be treated as bugs in upstream code. Container naming is a significant issue.
3. Try to genericize the changes, possibly turn some of them into switches that can be triggered at runtime, so that we can upstream them.
